### PR TITLE
Set Dependabot time

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,16 @@
 version: 2
 updates:
-- package-ecosystem: bundler
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  allow:
-  - dependency-type: direct
-  - dependency-type: indirect
-  ignore:
-  - dependency-name: omniauth-github
-    versions:
-    - "> 2.0.0, < 3"
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "08:45"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 10
+    allow:
+      - dependency-type: direct
+      - dependency-type: indirect
+    ignore:
+      - dependency-name: omniauth-github
+        versions:
+          - "> 2.0.0, < 3"


### PR DESCRIPTION
This gives me a consistent time when I can apply updates but allow's mikemcquaid/strap to get them first (so I can merge upstream and remove the need for the dependabot PR most of the time).

While we're here, allow VS Code to auto format the YAML.

Companion to https://github.com/MikeMcQuaid/strap/pull/573